### PR TITLE
docs: add tip for --changed-components in upgrade summary

### DIFF
--- a/commands/exp-foundation.md
+++ b/commands/exp-foundation.md
@@ -127,12 +127,24 @@ Create a new foundation version and selectively mark downstream experiments as s
    - **Previous foundation**: v1 (now stale)
    ```
 9. **Display Summary**:
+
+   **When `--changed-components` was provided:**
    ```
    Foundation v2 created (current).
    Foundation v1 marked stale.
    2 experiments marked stale (changed: cv).
    1 experiment skipped (not affected).
 
+   Next: Re-run key experiments with /exp-start on foundation v2.
+   ```
+
+   **When `--changed-components` was NOT provided:**
+   ```
+   Foundation v2 created (current).
+   Foundation v1 marked stale.
+   3 experiments marked stale.
+
+   Tip: Use --changed-components cv,labels to selectively mark stale.
    Next: Re-run key experiments with /exp-start on foundation v2.
    ```
 


### PR DESCRIPTION
## Summary
- `--changed-components` 미지정 시 upgrade summary에 Tip 안내 추가
- 선택적 stale 전파 기능의 discoverability 향상

## Context
v1.3.1 피드백: `--changed-components`를 깜빡하면 모든 실험이 stale 처리되는데, 사용자가 이 옵션의 존재를 모를 수 있음. blocking 경고 대신 summary에 한 줄 tip으로 안내.

## Changes
- `commands/exp-foundation.md`: upgrade summary를 `--changed-components` 제공/미제공 케이스로 분리, 미제공 시 `Tip: Use --changed-components cv,labels to selectively mark stale.` 추가

## Test plan
- [x] 단위 테스트 44개 통과 (문서 변경이므로 기존 테스트 영향 없음)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)