### PR TITLE
fix: omc_clear_date --clear flag + docs alignment (v1.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "exp-workflow",
       "source": "./",
-      "description": "Experiment lifecycle: /exp-init, /exp-start, /exp-status, /exp-finalize, /exp-milestone, /exp-foundation"
+      "description": "Experiment lifecycle: /exp-init, /exp-start, /exp-status, /exp-finalize, /exp-milestone, /exp-foundation + Date Field Roadmap support"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "exp-workflow",
   "description": "Experiment lifecycle management with GitHub Project integration, MANIFEST.yaml tracking, and automated logging",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "kyuwon"
   },

--- a/ci/omc-tools/omc-load-config
+++ b/ci/omc-tools/omc-load-config
@@ -120,7 +120,7 @@ omc_clear_date() {
     --project-id "$project_id" \
     --id "$item_id" \
     --field-id "$field_id" \
-    --date "" 2>/dev/null
+    --clear 2>/dev/null
 
   echo "Cleared Issue #$issue_num date field"
 }

--- a/skills/experiment-workflow/SKILL.md
+++ b/skills/experiment-workflow/SKILL.md
@@ -66,6 +66,7 @@ GitHub Project (칸반/마일스톤) + MANIFEST.yaml (결과 추적) + experimen
 10. **실험 시작 시 마일스톤 자동 연결**: MANIFEST milestone.title이 있으면 실험 항목에 milestone 필드 자동 추가
 11. **실험 시작 시 foundation 자동 연결**: MANIFEST foundations에서 `status: current`인 항목이 있으면 실험 항목에 `foundation` 필드 자동 추가 + `stale: false` 설정 + `depends_on_components` 설정 (`--depends-on` 플래그 지정 시 해당 값, 미지정 시 생략하여 전체 의존)
 12. **Foundation upgrade 시 선택적 stale 전파**: `--changed-components` 지정 시 해당 component에 의존하는 실험만 stale 처리. 미지정 시 전체 stale (v1.3.0 호환). 매칭 알고리즘: `experiment.depends_on_components ∩ changed_components ≠ ∅ → stale`. `depends_on_components` 미선언 실험은 전체 의존으로 간주하여 항상 stale.
+13. **Date Field 자동 연동**: `OMC_DATE_START_FIELD_ID` / `OMC_DATE_END_FIELD_ID`가 `.omc-config.sh`에 설정되어 있으면, `/exp-start` 시 Start Date를 오늘로 설정하고, `/exp-finalize` 시 Target Date를 오늘로 설정. `--reopen` 시 Target Date를 삭제(`--clear`). 미설정 시 날짜 필드 조작을 건너뜀 (graceful skip).
 
 ## MANIFEST.yaml Structure
 

--- a/tests/unit-test.sh
+++ b/tests/unit-test.sh
@@ -2,7 +2,7 @@
 # =============================================================================
 # exp-workflow Unit Test Script
 # =============================================================================
-# Tests 6 omc-tools scripts with mocked gh CLI (no network calls):
+# Tests 7 omc-tools scripts with mocked gh CLI (no network calls):
 #   omc-load-config, omc-feature-start, omc-feature-progress,
 #   omc-milestone-start, omc-milestone-status, omc-milestone-end,
 #   omc-backfill-dates
@@ -1610,7 +1610,7 @@ CONF_NODATE
     log_fail "I5. omc-feature-start skips date when empty" "Unexpected date calls found"
   fi
 
-  # I6. omc_clear_date calls gh project item-edit --date "" (not --clear)
+  # I6. omc_clear_date calls gh project item-edit --clear (not --date "")
   cat > "$TMPDIR/bin/gh" << 'GHSTUB_CLEAR'
 #!/bin/bash
 ALL_ARGS="$*"
@@ -1647,14 +1647,10 @@ CONF_CLEAR
     source $HOME/bin/omc-load-config 2>/dev/null
     omc_clear_date 99 'PVTF_end_test'
   " 2>/dev/null
-  if [ -f /tmp/omc-unit-clear-calls.txt ] && grep -q '\-\-date' /tmp/omc-unit-clear-calls.txt; then
-    if grep -q '\-\-clear' /tmp/omc-unit-clear-calls.txt; then
-      log_fail "I6. omc_clear_date uses --date (not --clear)" "Found --clear flag"
-    else
-      log_pass "I6. omc_clear_date uses --date to clear date field"
-    fi
+  if [ -f /tmp/omc-unit-clear-calls.txt ] && grep -q '\-\-clear' /tmp/omc-unit-clear-calls.txt; then
+    log_pass "I6. omc_clear_date uses --clear to clear date field"
   else
-    log_fail "I6. omc_clear_date uses --date to clear" "No --date call found"
+    log_fail "I6. omc_clear_date uses --clear to clear" "No --clear call found"
   fi
   rm -f /tmp/omc-unit-clear-calls.txt
 


### PR DESCRIPTION
## Summary
- **omc_clear_date**: `--date ""` → `--clear` (correct gh CLI flag for clearing project item fields)
- **Test I6**: Inverted assertion to verify `--clear` flag presence
- **SKILL.md**: Added rule #13 documenting Date Field auto-integration behavior
- **unit-test.sh header**: Updated script count from 6 → 7
- **marketplace.json**: Added "Date Field Roadmap support" to plugin description
- **plugin.json**: Version bump 1.4.0 → 1.4.1

## Test plan
- [x] 64/64 unit tests pass (including updated I6)
- [x] Architect verification: APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>