### PR TITLE
feat: experiment label tests + SKILL.md triggers + status detail mode (v1.5.1)

### DIFF
--- a/commands/exp-status.md
+++ b/commands/exp-status.md
@@ -91,7 +91,51 @@ If no active milestone in MANIFEST, show all experiments without grouping (backw
 - Open experiments show blank Target Date.
 
 #### Detail Mode (with experiment ID)
-Shows: Issue info, branch, task checklist, output files, recent commits, Start Date, Target Date.
+When an experiment ID is provided (e.g., `/exp-status e003`):
+
+1. **Read MANIFEST**: Find experiment entry by ID. If not found, show available experiments and exit.
+2. **Fetch GitHub Issue data**:
+```bash
+gh issue view {issue_number} --repo "$OMC_GH_REPO" --json title,state,body,labels,createdAt
+```
+3. **Extract task checklist**: Parse issue body for `- [ ]` and `- [x]` patterns, compute completion ratio.
+4. **List output files**:
+```bash
+ls -la outputs/e{NUM}/ 2>/dev/null
+```
+5. **Recent commits on branch**:
+```bash
+git log --oneline -5 {branch_name} 2>/dev/null
+```
+6. **Fetch Date fields** (if configured):
+   Same as overview mode — query `gh project item-list` for Start Date and Target Date.
+
+7. **Display**:
+```
+Experiment e003: DEG Analysis
+  Status:       experimental
+  Foundation:   v2 (current)
+  Depends On:   labels
+  Stale:        no
+  Issue:        #8 (open)
+  Branch:       feature-8
+  Start Date:   2026-02-15
+  Target Date:  -
+  Milestone:    v1.0-foundation
+
+  Tasks: [####........] 2/4
+    [x] Plan 작성
+    [x] 실험 실행
+    [ ] 결과 검증
+    [ ] 결과 해석
+
+  Outputs:
+    (none yet)
+
+  Recent Commits:
+    a1b2c3d Add DEG analysis script
+    e4f5g6h Initial experiment setup
+```
 
 ### 6. Edge Cases
 - No MANIFEST.yaml → "Run /exp-init"

--- a/skills/experiment-workflow/SKILL.md
+++ b/skills/experiment-workflow/SKILL.md
@@ -15,6 +15,8 @@ GitHub Project (칸반/마일스톤) + MANIFEST.yaml (결과 추적) + experimen
 - "e{NUM} 실험 시작" → /exp-workflow:exp-start
 - "실험 현황" / "진행 상황" → /exp-workflow:exp-status
 - "final로 해줘" / "확정" → /exp-workflow:exp-finalize
+- "폐기" / "deprecated" / "실험 폐기" → /exp-workflow:exp-finalize --deprecate
+- "재개" / "다시 열기" / "reopen" / "실험 재실행" → /exp-workflow:exp-finalize --reopen
 - "프로젝트 초기화" → /exp-workflow:exp-init
 - "마일스톤 시작" / "milestone start" → /exp-milestone start
 - "마일스톤 현황" / "milestone status" → /exp-milestone status

--- a/tests/unit-test.sh
+++ b/tests/unit-test.sh
@@ -207,6 +207,12 @@ case "$ALL_ARGS" in
   *"project field-list"*)
     echo '{"fields":[{"name":"Status","id":"PVTSSF_test","options":[]}]}'
     ;;
+  *"label create"*)
+    echo "Label created"
+    ;;
+  *"issue edit"*"--add-label"*)
+    echo "ok"
+    ;;
   *)
     echo "gh-stub: unhandled: $ALL_ARGS" >&2
     exit 0
@@ -2234,6 +2240,45 @@ GHSTUB
 }
 
 # ---------------------------------------------------------------------------
+# K. Experiment Label Support (4 tests)
+# ---------------------------------------------------------------------------
+test_experiment_label() {
+  log_section "K. Experiment Label Support (4 tests)"
+
+  # K1. exp-start.md contains --add-label experiment instruction
+  assert_file_contains \
+    "$PROJECT_ROOT/commands/exp-start.md" \
+    'add-label "experiment"' \
+    "K1. exp-start.md contains --add-label experiment instruction"
+
+  # K2. exp-init.md contains gh label create experiment instruction
+  assert_file_contains \
+    "$PROJECT_ROOT/commands/exp-init.md" \
+    'label create "experiment"' \
+    "K2. exp-init.md contains gh label create experiment instruction"
+
+  # K3. gh stub handles label create command (exits 0)
+  local label_output
+  label_output=$(gh label create "experiment" --color "7B68EE" --repo "test/repo" 2>&1)
+  local label_exit=$?
+  if [ $label_exit -eq 0 ]; then
+    log_pass "K3. gh label create exits 0 (no error)"
+  else
+    log_fail "K3. gh label create exits 0 (no error)" "Exit code: $label_exit, output: $label_output"
+  fi
+
+  # K4. gh stub handles issue edit --add-label command (exits 0)
+  local edit_output
+  edit_output=$(gh issue edit 42 --add-label "experiment" --repo "test/repo" 2>&1)
+  local edit_exit=$?
+  if [ $edit_exit -eq 0 ]; then
+    log_pass "K4. gh issue edit --add-label exits 0 (no error)"
+  else
+    log_fail "K4. gh issue edit --add-label exits 0 (no error)" "Exit code: $edit_exit, output: $edit_output"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 print_summary() {
@@ -2279,6 +2324,7 @@ main() {
   test_selective_stale_propagation
   test_date_field_support
   test_backfill_dates
+  test_experiment_label
 
   print_summary
 


### PR DESCRIPTION
## Summary
- K section 단위테스트 4개 추가 (experiment 라벨 gh stub 검증)
- SKILL.md에 `--deprecate`/`--reopen` 트리거 패턴 추가
- exp-status detail 모드 7단계 절차 보강
- stale 로컬 브랜치 4개 정리

## Test plan
- [x] 71/71 단위테스트 통과
- [x] K1-K4 experiment 라벨 테스트 통과
- [x] gh stub에 label create / issue edit --add-label 명시적 case arm 추가
- [ ] CI 파이프라인 통과 확인

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)